### PR TITLE
 Correctif Dropzone vue css . 

### DIFF
--- a/src/views/forms/fields/dropzone.blade.php
+++ b/src/views/forms/fields/dropzone.blade.php
@@ -100,6 +100,7 @@
                             readURL(elInput.get(0));
                         }
                         else {
+                            elInput.parent().css({'background-image': ''});
                             elInput.parent().addClass('is-video-image')
                         }
                         


### PR DESCRIPTION
Lorsque l'on uploadait une vidéo puis une image. La preview ne changeait pas mais le fichier était bien updaté.